### PR TITLE
Hide the logout menu entry

### DIFF
--- a/superset/templates/head_custom_extra.html
+++ b/superset/templates/head_custom_extra.html
@@ -22,3 +22,9 @@
   It will be included in the head block in every view in superset and is a
   good place to include your custom link, meta, style or script elements.
 #}
+<style>
+li.antd5-menu-item-group li.antd5-menu-item[data-menu-id^="rc-menu-"][data-menu-id$="-logout"]
+{
+  display: none;
+}
+</style>


### PR DESCRIPTION
Should use logout from the header, not from superset

Hide the menu entry using some CSS.